### PR TITLE
docs: restructure project generator architecture ADR; add more options

### DIFF
--- a/docs/architecture-decisions/ADR_001_project_generator_architecture.md
+++ b/docs/architecture-decisions/ADR_001_project_generator_architecture.md
@@ -1,18 +1,32 @@
-# ADR-001: AlgoKit Project Generator Architecture - Transition to Modular Generator System
+---
+status: proposed
+date: 2024-12-17
+decision-makers: David Rojas 
+consulted: AlgoKit Core Team, Algorand DevRel, MakerX engineering team
+---
 
-## Status
-Proposed
+# Transition to Modular Generator System for `AlgoKit` Project Architecture
 
-## Background Context
+## Context and Problem Statement
 
-### Current System Overview
-The AlgoKit ecosystem currently consists of two main repositories working in tandem. The algokit-templates repository uses Copier as its templating engine, organizing templates into base templates (workspace, contracts, frontend) and example templates that demonstrate specific use cases. Project composition is managed through an `examples.yml` configuration file that defines how templates are layered together. The algokit-cli repository provides the user interface through `algokit init` for project creation and `algokit generate` for adding components to existing projects. The system supports various features including preset configurations (starter vs production), post-generation hooks for configuration merging, IDE integration for VSCode and JetBrains, and maintains a curated list of "blessed" templates. The examples folder contains fully hydrated projects that serve dual purposes: providing reference implementations and populating the AlgoKit example gallery.
+The `AlgoKit` ecosystem currently uses a template-based architecture where projects are generated from monolithic templates. How can we evolve this system to provide better modularity, incremental enhancement capabilities, and user control while maintaining the current feature set and user experience? The current system has limitations in diff preview, conflict detection, compatibility management, and feature status tracking that need to be addressed.
 
-### Terminology and Definitions
+## Decision Drivers
 
-**Project**: An AlgoKit-managed codebase that contains one or more related applications or components for Algorand development. A project is defined by the presence of an .algokit.toml configuration file and can be structured as either a single-purpose project (containing only smart contracts OR only frontend code) or a workspace project (containing multiple related sub-projects such as both smart contracts and frontend applications). Projects track their applied generators, configuration, and metadata through the .algokit.toml file, enabling incremental enhancement and state management throughout the development lifecycle.
+* **Developer Experience**: Need for incremental project building, diff preview before changes, and clear feature status tracking
+* **Modularity Requirements**: Features should be composable, idempotent, and applicable at any point in project lifecycle
+* **Multiple User Workflows**: Support TUI wizard for beginners, CLI commands for experienced developers, and configuration files for teams
+* **Maintenance Burden**: Current template duplication across repositories creates significant maintenance overhead
+* **Self-Contained Execution**: Eliminate manual dependency installation requirements
+* **Backward Compatibility**: Maintain existing functionality while transitioning to new architecture
 
-**Example Project**: A fully-hydrated AlgoKit project that demonstrates a complete, functional implementation of a specific use case or pattern. Example projects are created by applying base, feature, and example generators in sequence to produce ready-to-run applications that serve as both reference implementations for developers and entries in the AlgoKit gallery.
+## ADR Glossary
+
+> Glossary of terms used within this ADR, including existing concepts as well as new terminology relevant to generators proposal in option 1. The glossary will be updated to reflect which *new* terms will take effect depending on decision in the ADR.
+
+**Project**: An `AlgoKit`-managed codebase that contains one or more related applications or components for Algorand development. A project is defined by the presence of an `.algokit.toml` configuration file and can be structured as either a single-purpose project (containing only smart contracts OR only frontend code) or a workspace project (containing multiple related sub-projects such as both smart contracts and frontend applications). Projects track their applied generators, configuration, and metadata through the `.algokit.toml` file, enabling incremental enhancement and state management throughout the development lifecycle.
+
+**Example Project**: A fully-hydrated `AlgoKit` project that demonstrates a complete, functional implementation of a specific use case or pattern. Example projects are created by applying base, feature, and example generators in sequence to produce ready-to-run applications that serve as both reference implementations for developers and entries in the `AlgoKit` gallery.
 
 **Generator**: A self-contained, modular unit that applies a specific set of transformations to create or modify project files, configurations, and structure. Generators are designed to be idempotent, meaning they can be executed multiple times on the same project without causing unintended side effects - subsequent runs will either produce the same result or gracefully handle existing configurations without duplication or corruption.
 
@@ -24,25 +38,28 @@ The AlgoKit ecosystem currently consists of two main repositories working in tan
 
 ## User Workflows Requirements
 
-**Workflow 1: Interactive TUI Wizard**
+### Workflow 1: Interactive TUI Wizard
+
 As a developer new to Algorand, I want to use an interactive wizard that guides me through project creation, so that I can easily select the features I need without understanding all the technical details upfront. The wizard should present me with clear options for project type, language preferences, and additional features like testing frameworks, linting tools, and IDE configurations. After creating my initial project, I should be able to run commands like `algokit project add testing` or `algokit project add linting` to incrementally enhance my project with new capabilities.
 
-**Workflow 2: Incremental Command-Line Building**
+### Workflow 2: Incremental Command-Line Building
+
 As an experienced developer, I want to build my project incrementally using explicit commands, so that I have full control over the project structure and can automate the process in CI/CD pipelines. I should be able to start with `algokit project add workspace` to create a workspace structure, then add components like `algokit project add base --contracts --python` for smart contracts and `algokit project add base --frontend --react` for the frontend. This approach allows me to build exactly what I need, when I need it, and understand each layer being added to my project.
 
 Example commands:
+
 ```bash
 # Creates workspace structure
 algokit project add workspace
 
 # Adds Python contract base
-algokit project add base --contracts --python
+algokit project add base-contracts-python
 
 # Adds TypeScript contract base
-algokit project add base --contracts --typescript
+algokit project add base-contracts-typescript
 
 # Adds React frontend base
-algokit project add base --frontend --react
+algokit project add base-frontend-react
 
 # Auto-detects project type and adds testing
 algokit project add testing
@@ -54,701 +71,400 @@ algokit project add linting
 algokit project add formatting
 ```
 
-**Workflow 3: Configuration-Based Generation**
+### Workflow 3: Configuration-Based Generation
+
 As a team lead or architect, I want to define my project structure in a configuration file and generate consistent projects from it, so that my team can quickly spin up standardized projects that follow our architectural patterns. I should be able to create a YAML configuration that specifies all the generators to apply in sequence, including base templates, example code, and features. This configuration should be versionable, shareable, and reproducible across different environments, enabling commands like `algokit project generate --config my-template.yml`.
 
-## Project Generator Requirements
+## Current System Overview
 
-### 1. Core Capabilities
-- **Configuration-Based Generation**: Project generation SHALL run from a configuration and SHALL have all agreed-upon features that currently exist in the templates (e.g. use_python_pytest, use_jest, use_vitest, use_playwright etc.)
-- **Feature Modularity and Idempotency**: Project generation features (e.g. testing, formatting, linting) SHALL be modular and idempotent. Features SHALL be able to be run (or added) at any point in the lifecycle of the project. Each feature SHALL be able to be run on top of any existing project in an idempotent way. Note: The order in which features are added does matter
-- **Lifecycle Flexibility**: Features SHALL be addable at any point in the project lifecycle
-- **Project Structure Support**: The project generator SHALL support users creating projects in a VSCode workspace or a non-workspace project structure
-
-### 2. User Interaction
-- **Project Creation Methods**: Users SHALL be able to manually form a project from scratch by adding project features manually, specifying a configuration, or using an init wizard
-- **Feature Addition Workflow with Diff Preview**: When adding a feature to a project, the project generator SHALL show the user the diff of what will be added. User approval SHALL be required before proceeding (similar to astro add functionality)
-- **Conflict Detection and Resolution**: When adding a feature, the project generator SHALL check if the feature has already been added (either by configuration or existence of files/directories). The project generator SHALL warn the user that files will be overwritten if they proceed with feature generation
-
-### 3. Project Management
-- **Feature Status Tracking**: While in an AlgoKit project, users SHALL be able to determine status of what features have been added to the project
-- **Version Tracking**: The project generator SHALL be able to know what version of the project generator was used to generate the project
-- **Compatibility Management**: The project generator SHALL be able to know if there are compatibility issues between the project generator used to generate the project and the project generator being used to add a feature. The project generator SHALL flag the user to these compatibility issues or error if the compatibility issues are not reconcilable
-
-### 4. Non Functional Requirements
-- **No Manual Dependency Installation**: The project generator SHALL NOT require a user to manually install a python dependency or any other required dependencies in order to run the project generator
+```mermaid
+flowchart TD
+    A[AlgoKit CLI] --> B{Command Type}
+    
+    B -->|init| C[Init Command]
+    B -->|init examples| D[Init Examples Subcommand]
+    
+    C --> E[Template Selection]
+    E --> F{Predefined Template}
+    
+    F -->|python| G[Python Template Repo]
+    F -->|react| H[React Template Repo]
+    F -->|typescript| I[TypeScript Template Repo]
+    F -->|fullstack| K[Fullstack Template Repo]
+    
+    G --> L[Copier Invocation]
+    H --> L
+    I --> L
+    K --> L
+    
+    L --> M[Generate Project]
+    
+    D --> N[TUI Interface for Example Selection]
+    N --> O[User Configuration]
+    O --> P
+    Z --> P[Copy Ready-Made Example from Template Monorepo]
+    P --> Z[AlgoKit Templates Monorepo]
+```
 
 ## Current Gaps
 
-**Diff Preview and Approval System**
+### Diff Preview and Approval System
+
 The current implementation applies changes directly without showing users what will be modified. There is no mechanism to preview changes before they are applied, and no approval workflow exists. This makes users hesitant to run generators on existing projects as they cannot predict the impact.
 
-**Intelligent Conflict Detection**
+### Intelligent Conflict Detection
+
 While Copier provides basic file overwrite warnings, there is no intelligent detection of feature conflicts. The system cannot determine if a feature has already been added by examining project configuration or file patterns. This can lead to duplicate configurations or broken setups when features are added multiple times.
 
-**Comprehensive Compatibility Management**
-The current system has basic version requirement checking but lacks a compatibility matrix between generator versions. There are no automated migration paths when upgrading generators, and no clear way to handle breaking changes between versions. Projects can become stuck on old generator versions with no upgrade path.
+### Scattered Feature Status Tracking
 
-**Self-Contained Execution Environment**
-Users must manually install Python and other dependencies before using AlgoKit. The typed client generators require separate package installations (`@algorandfoundation/algokit-client-generator` for TypeScript, `algokit-client-generator` for Python). This creates barriers to entry and potential version conflicts.
-
-**Scattered Feature Status Tracking**
 Feature configuration is distributed across multiple files (`.copier-answers.yml`, `.algokit.toml`, `pyproject.toml`, `package.json`). There is no single command to view all enabled features and their status. Users must manually inspect multiple files to understand their project configuration.
 
-## Options
+## Considered Options
 
-### Option 1: Flat Generator Architecture with State in .algokit.toml
+* **Option 1: Flat Generator Architecture with State in .algokit.toml** - Transform current templates into independent generators with centralized state management
+* **Option 2: Dedicated generators monorepo with support for both inline and remote generators** - Extension to Option 1 with separate monorepos for generators and examples
+* **Option 3: Hybrid approach enhancing existing standalone templates and remote generators** - Enhancement of existing patterns with gradual introduction of modularity
+* **Option 4: CLI-Integrated Generator Engine** - All generators embedded within CLI binary to eliminate external version dependencies
 
-#### Overview
-Transform the current template system into a flat generator architecture where every feature (workspace setup, base templates, testing, linting, etc.) is implemented as an independent, composable generator. State management is centralized in the project's `.algokit.toml` file, providing transparency and version control friendliness.
+## Decision Outcome
 
-#### Functionality Distribution
+To be decided. Current AlgoKit Core and MakerX Engineer team consensus is to pursue Option 2 and consider migrating to Option 4 in the longer term.
 
-| Functionality | CLI Repo | Templates Repo | Notes |
-|--------------|----------|----------------|-------|
-| TUI Wizard Interface | ✓ | | Interactive UI for project initialization |
-| CLI Command Parsing | ✓ | | Parse and validate user commands |
-| Generator Discovery | ✓ | | Query available generators from templates |
-| Generator Metadata | | ✓ | Dependencies, compatibility, descriptions |
-| Generator Implementation | | ✓ | All copier templates and transformation logic |
-| Workflow Orchestration | ✓ | | Sequential application of generators |
-| State Management | ✓ | | Track applied generators in .algokit.toml |
-| Project Type Detection | ✓ | | Analyze existing project structure |
-| Configuration Parsing | ✓ | | Parse YAML/TOML configuration files |
-| Compatibility Checking | ✓ | | Validate generator combinations |
-| Example Configurations | | ✓ | YAML files defining example projects |
-| Hydrated Examples | | ✓ | Full example projects for app gallery |
-| Diff Preview Engine | ✓ | | Show changes before applying |
-| Conflict Resolution | ✓ | | Handle file conflicts during generation |
-| Version Management | ✓ | | Track generator versions in .algokit.toml |
+### Confirmation
 
-#### Repository Structure
+Implementation success will be confirmed through:
 
-**Templates Repository:**
-```
-algokit-templates/
-├── generators/                           # All generators (flat structure)
-│   ├── workspace/                       # Creates workspace structure
-│   ├── base-contracts-python/           # Python contract base
-│   ├── base-contracts-typescript/       # TypeScript contract base
-│   ├── base-frontend-react/             # React frontend base
-│   ├── create-smart-contract/           # Create new smart contract
-│   ├── testing/                         # Add testing (auto-detects type)
-│   ├── linting/                         # Add linting configuration
-│   ├── formatting/                      # Add code formatting
-│   ├── devcontainer/                    # Add devcontainer support
-│   ├── ci-cd/                           # Add CI/CD workflows
-│   ├── env-file/                        # Create environment files
-│   ├── example-digital-marketplace/     # Digital marketplace delta
-│   └── example-hello-world/             # Hello world delta
-├── examples/                            # Fully hydrated examples
-│   ├── examples.yml                     # Configuration for generating examples
-│   ├── python-smart-contract/           # Complete project for app gallery
-│   └── digital-marketplace/             # Complete project for app gallery
-└── scripts/
-    └── generate-examples.py             # Build examples from configurations
-```
+* Successful generation of all current example projects using the new generator architecture
+* Validation that all existing template features are preserved and functional
+* User acceptance testing of the three primary workflows (TUI, CLI, configuration-based)
+* Compatibility testing with existing `AlgoKit` projects
 
-**CLI Repository:**
-```
-algokit-cli/
-└── src/
-    └── algokit/
-        ├── cli/
-        │   ├── project/
-        │   │   ├── __init__.py
-        │   │   ├── init.py              # TUI wizard implementation
-        │   │   ├── add.py               # Incremental commands
-        │   │   └── generate.py          # Configuration-based generation
-        │   └── ...
-        └── core/
-            ├── project/
-            │   ├── __init__.py
-            │   ├── generator_registry.py # Discover available generators
-            │   ├── state_manager.py      # Manage state in .algokit.toml
-            │   └── compatibility.py      # Check generator compatibility
-            └── ...
-```
+## 1. Flat Generator Architecture with State in .algokit.toml
 
-#### Schema Configuration
+Transform the current template system into a flat generator architecture where every feature (workspace setup, base templates, testing, linting, etc.) is implemented as an independent, composable generator. State management is centralized in the project's `.algokit.toml` file, providing transparency and version control friendliness. Enforce proper JSON schema for all configuration files including `.algokit.toml` and introduce explicit validation of the schemas in the cli during project metadata parsing.
 
-##### AlgoKit Project Configuration Schema (.algokit.toml)
+### Schema-Driven Configuration
 
-The `.algokit.toml` configuration file will undergo several changes to support the new generator architecture:
+This option introduces formal JSON schemas for both project configuration and template definitions:
 
-```toml
-[algokit]
-min_version = "v2.0.0"  # Remains unchanged
+* **Project Configuration Schema**: Defines the structure of `.algokit.toml` files with generator tracking, version management, and validation rules. See [algokit-toml-schema.json](assets/ADR_001/algokit-toml-schema.json) for the complete specification.
 
-[project]
-# CHANGED: type enum now only includes: contracts, frontend, fullstack
-# REMOVED: "workspace" and "backend" as types (workspace is now a generator)
-type = "fullstack"  
-name = "my-project"
+* **Template Configuration Schema**: Defines reusable project templates that specify generator sequences for common project patterns. See [template-config-schema.json](assets/ADR_001/template-config-schema.json) for the complete specification.
 
-# projects_root_path is only required when workspace generator is applied
-projects_root_path = "projects"
+* **Configuration Examples**: Reference implementations showing typical project configurations and template definitions are available in the [assets/ADR_001/](assets/ADR_001/) folder.
 
-# NEW: Track all applied generators with metadata
-[project.generators]
-workspace = { version = "1.0.0", timestamp = "2024-01-01T00:00:00Z" }
-"base-contracts-python" = { version = "1.0.0", timestamp = "2024-01-01T00:01:00Z" }
-"base-frontend-react" = { version = "1.0.0", timestamp = "2024-01-01T00:02:00Z" }
-testing = { version = "1.0.0", timestamp = "2024-01-01T00:03:00Z", detected_type = "python_contract" }
-linting = { version = "1.0.0", timestamp = "2024-01-01T00:04:00Z" }
-
-# Remains unchanged - populated by generators
-[project.run]
-test = { commands = ["poetry run pytest"], description = "Run smart contract tests" }
-lint = { commands = ["poetry run ruff check"], description = "Check code style" }
-format = { commands = ["poetry run black ."], description = "Format code" }
-
-# Remains unchanged
-[project.deploy]
-command = "poetry run python -m smart_contracts deploy"
-environment_secrets = ["DEPLOYER_MNEMONIC"]
-
-# REMOVED: The entire [generate] section
-# Previously:
-# [generate.smart-contract]
-# description = "Generate a new smart contract"
-# path = ".algokit/generators/smart-contract"
-#
-# This functionality is replaced by `algokit project add` commands
-```
-
-Key changes:
-- `project.type` now limited to `contracts`, `frontend`, or `fullstack`
-- Added `project.generators` to track applied generators with metadata
-- Removed the entire `[generate]` section as generators are no longer embedded in projects
-- Workspace identification now done by checking if `workspace` exists in `project.generators`
-
-###### Updated JSON Schema
-
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "AlgoKit Configuration Schema",
-  "description": "JSON Schema for .algokit.toml configuration files used by AlgoKit CLI",
-  "type": "object",
-  "properties": {
-    "algokit": {
-      "type": "object",
-      "description": "AlgoKit CLI-specific configuration",
-      "properties": {
-        "min_version": {
-          "type": "string",
-          "description": "Minimum required version of AlgoKit CLI",
-          "pattern": "^v?\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?$",
-          "examples": ["v2.0.0", "1.3.1", "v1.1.0-beta.4"]
-        }
-      },
-      "additionalProperties": false
-    },
-    "project": {
-      "type": "object",
-      "description": "Project configuration and metadata",
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "Type of AlgoKit project",
-          // CHANGED: Removed "workspace" and "backend", now only core types
-          "enum": ["contracts", "frontend", "fullstack"]
-        },
-        "name": {
-          "type": "string",
-          "description": "Name of the project",
-          "minLength": 1
-        },
-        "projects_root_path": {
-          "type": "string",
-          "description": "Root path for sub-projects in a workspace",
-          "minLength": 1
-        },
-        "artifacts": {
-          "type": "string",
-          "description": "Path to artifacts directory for contract projects",
-          "minLength": 1
-        },
-        // NEW: Track applied generators with metadata
-        "generators": {
-          "type": "object",
-          "description": "Track applied generators with metadata",
-          "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
-              "$ref": "#/$defs/generatorMetadata"
-            }
-          },
-          "additionalProperties": false
-        },
-        "deploy": {
-          "$ref": "#/$defs/deployConfig"
-        },
-        "run": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/workspaceRunConfig"
-            },
-            {
-              "$ref": "#/$defs/standaloneRunConfig"
-            }
-          ]
-        }
-      },
-      // CHANGED: Conditional logic now based on generators instead of type
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "generators": {
-                "properties": {
-                  "workspace": {
-                    "type": "object"
-                  }
-                },
-                "required": ["workspace"]
-              }
-            }
-          },
-          "then": {
-            "required": ["projects_root_path"]
-          }
-        }
-      ],
-      "required": ["type", "name"],
-      "additionalProperties": false
-    },
-    // REMOVED: The entire "generate" section - generators are no longer embedded
-    // "generate": {
-    //   "type": "object",
-    //   "description": "Custom generator configurations",
-    //   "patternProperties": {
-    //     "^[a-zA-Z0-9_-]+$": {
-    //       "$ref": "#/$defs/generatorConfig"
-    //     }
-    //   },
-    //   "additionalProperties": false
-    // },
-    "deploy": {
-      "$ref": "#/$defs/deployConfig",
-      // Still present but should be deprecated
-      "description": "Legacy deploy configuration (deprecated, use project.deploy instead)"
-    }
-  },
-  "additionalProperties": false,
-  "$defs": {
-    // NEW: Definition for generator metadata
-    "generatorMetadata": {
-      "type": "object",
-      "description": "Metadata for an applied generator",
-      "properties": {
-        "version": {
-          "type": "string",
-          "description": "Version of the generator that was applied",
-          "pattern": "^\\d+\\.\\d+\\.\\d+$"
-        },
-        "timestamp": {
-          "type": "string",
-          "description": "ISO 8601 timestamp when generator was applied",
-          "format": "date-time"
-        },
-        "source": {
-          "type": "string",
-          "description": "Source of the generator (e.g., 'official', URL)",
-          "default": "official"
-        },
-        "detected_type": {
-          "type": "string",
-          "description": "Auto-detected project type for context-aware generators"
-        }
-      },
-      "required": ["version", "timestamp"],
-      "additionalProperties": true
-    },
-    // REMOVED: generatorConfig definition - no longer needed
-    // "generatorConfig": {
-    //   "type": "object",
-    //   "description": "Generator configuration",
-    //   "properties": {
-    //     "path": {
-    //       "type": "string",
-    //       "description": "Path to the generator template",
-    //       "minLength": 1
-    //     },
-    //     "description": {
-    //       "type": "string",
-    //       "description": "Description of what the generator does",
-    //       "minLength": 1
-    //     }
-    //   },
-    //   "required": ["path"],
-    //   "additionalProperties": false
-    // },
+```mermaid
+flowchart TD
+    A[AlgoKit CLI] --> B{Command Type}
     
-    // The following definitions remain unchanged
-    "deployConfig": {
-      "type": "object",
-      "description": "Deployment configuration",
-      "properties": {
-        "command": {
-          "oneOf": [
-            {
-              "type": "string",
-              "description": "Deploy command as a string",
-              "minLength": 1
-            },
-            {
-              "type": "array",
-              "description": "Deploy command as an array of strings",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1
-            }
-          ]
-        },
-        "environment_secrets": {
-          "type": "array",
-          "description": "List of environment variable names to treat as secrets",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "uniqueItems": true
-        }
-      },
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
-          "description": "Network-specific deployment configuration",
-          "properties": {
-            "command": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "description": "Deploy command as a string for this network",
-                  "minLength": 1
-                },
-                {
-                  "type": "array",
-                  "description": "Deploy command as an array of strings for this network",
-                  "items": {
-                    "type": "string"
-                  },
-                  "minItems": 1
-                }
-              ]
-            },
-            "environment_secrets": {
-              "type": "array",
-              "description": "List of environment variable names to treat as secrets for this network",
-              "items": {
-                "type": "string",
-                "minLength": 1
-              },
-              "uniqueItems": true
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "workspaceRunConfig": {
-      "type": "object",
-      "description": "Workspace run configuration defining execution order",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "array",
-          "description": "Ordered list of project names for command execution",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "uniqueItems": true
-        }
-      },
-      "additionalProperties": false
-    },
-    "standaloneRunConfig": {
-      "type": "object",
-      "description": "Standalone project run configuration",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "$ref": "#/$defs/customCommand"
-        }
-      },
-      "additionalProperties": false
-    },
-    "customCommand": {
-      "type": "object",
-      "description": "Custom command configuration",
-      "properties": {
-        "commands": {
-          "type": "array",
-          "description": "List of commands to execute",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "minItems": 1
-        },
-        "description": {
-          "type": "string",
-          "description": "Description of what the command does",
-          "minLength": 1
-        },
-        "env_file": {
-          "type": "string",
-          "description": "Path to environment file to load",
-          "minLength": 1
-        }
-      },
-      "required": ["commands"],
-      "additionalProperties": false
-    }
-  }
-}
+    B -->|init| C[Init Command]
+    B -->|init examples| D[Init Examples Subcommand]
+    
+    C --> E[TUI Interface for Template Selection]
+    E --> P[Custom YAML Assembly]
+    P --> Q[algokit-templates Monorepo]
+    Q --> X[Sequential generation]
+
+    X --> Y[Final Custom Project Assembly]
+    D --> N[TUI Interface for Example Selection]
+    N --> Z[Copy Ready-Made Example from Template Monorepo]
+    Z --> Q
+    Q --> Z
 ```
 
-##### AlgoKit Template Configuration Schema
+### Migration and Backward Compatibility
 
-The AlgoKit Template Configuration Schema defines reusable project templates that specify which generators to apply in sequence. This replaces the current `examples.yml` structure with a simplified format focused only on essential fields.
+#### Impact on Existing Templates
 
-###### YAML Example
-```yaml
-# Simplified schema - only essential fields
-id: "python-fullstack-marketplace"
-name: "Digital Marketplace" 
-generators:
-  - name: workspace
-  - name: base-contracts-python
-  - name: create-smart-contract
-    data:
-      language: python
-      contract_name: "digital_marketplace"
-  - name: base-frontend-react
-  - name: example-digital-marketplace
-  - name: testing
-  - name: linting
-  - name: devcontainer
-```
+Currently, `AlgoKit` templates are maintained as individual GitHub repositories containing full Copier templates. These standalone repositories will undergo a phased deprecation process, remaining functional but marked as deprecated initially, then archived after the `--legacy` flag is removed from the CLI.
 
-###### TOML Example
-```toml
-id = "python-fullstack-marketplace"
-name = "Digital Marketplace"
-
-[[generators]]
-name = "workspace"
-
-[[generators]]
-name = "base-contracts-python"
-
-[[generators]]
-name = "create-smart-contract"
-[generators.data]
-language = "python"
-contract_name = "digital_marketplace"
-
-[[generators]]
-name = "base-frontend-react"
-
-[[generators]]
-name = "example-digital-marketplace"
-
-[[generators]]
-name = "testing"
-
-[[generators]]
-name = "linting"
-
-[[generators]]
-name = "devcontainer"
-```
-
-###### JSON Schema
-```json
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "AlgoKit Template Configuration Schema",
-  "description": "Schema for AlgoKit template configuration files",
-  "type": "object",
-  "properties": {
-    "id": {
-      "type": "string",
-      "description": "Unique identifier for the template",
-      "pattern": "^[a-z0-9-]+$"
-    },
-    "name": {
-      "type": "string", 
-      "description": "Human-readable name for the template",
-      "minLength": 1
-    },
-    "generators": {
-      "type": "array",
-      "description": "List of generators to apply in sequence",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the generator to apply"
-          },
-          "data": {
-            "type": "object",
-            "description": "Optional data to pass to the generator",
-            "additionalProperties": true
-          }
-        },
-        "required": ["name"],
-        "additionalProperties": false
-      },
-      "minItems": 1
-    }
-  },
-  "required": ["id", "name", "generators"],
-  "additionalProperties": false
-}
-```
-
-Key changes from current `examples.yml`:
-- `project_name` becomes `name`
-- `templates` becomes `generators` 
-- Only `id`, `name`, and `generators` are required for template execution
-- Additional metadata fields (type, author, title, description, tags, features, detailsPages) can still be included for project gallery display but are not needed to run generators
-- Each generator entry only needs `name` and optional `data`
-- Simplified core structure focused on defining what generators to run in sequence
-
-### Workflow Implementation
-
-**Workflow 1: Interactive Wizard (TUI)**
-There is a spike for this TUI [here](https://github.com/lempira/template-gallery-spike) Look at the end for a video of the TUI. 
-
-```
-CLI Repo                          Templates Repo
---------                          --------------
-TUI Wizard -----------------> Query generators/*/copier.yaml
-    |                              |
-Present feature choices            v
-    |                         Return generator metadata
-    v                              |
-User selects features              |
-    |                              |
-Validate selections <--------------+
-    |
-Apply generators sequentially --> Execute each generator
-    |                              |
-Update .algokit.toml               v
-    |                         Apply template files
-    v
-Complete project
-```
-
-**Workflow 2: Incremental CLI Commands**
-
-Command to Generator Mapping:
-
-| Command | Generator Name |
-|---------|---------------|
-| `add workspace` | `workspace` |
-| `add base --contracts --python` | `base-contracts-python` |
-| `add base --contracts --typescript` | `base-contracts-typescript` |
-| `add base --frontend --react` | `base-frontend-react` |
-| `add testing` | `testing` |
-| `add linting` | `linting` |
-| `add formatting` | `formatting` |
-
-**Workflow 3: Configuration-Based Generation**
-```yaml
-project:
-  id: python-fullstack-marketplace
-  name: "Digital Marketplace"
-  # Additional metadata that can be used for any purpose e.g. example gallery
-  
-  # Generators applied in order
-  # This is the only config that is needed to build a project
-  # Each generator can run no data because of defaults but can be overridden with the data config.    
-  generators:
-    - name: workspace
-      
-    - name: base-contracts-python
-      
-    - name: create-smart-contract
-      data:
-        language: python
-        contract_name: digital_marketplace
-        
-    - name: example-digital-marketplace
-      
-    - name: base-frontend-react
-      
-    - name: testing
-      
-    - name: linting
-      
-    - name: formatting
-      
-    - name: devcontainer
-```
-
-#### Migration and Backward Compatibility
-
-##### Impact on Existing Templates
-
-Currently, AlgoKit templates are maintained as individual GitHub repositories containing full Copier templates. These standalone repositories will undergo a phased deprecation process, remaining functional but marked as deprecated initially, then archived after the `--legacy` flag is removed from the CLI.
-
-All Algorand Foundation maintained templates will be migrated to the new generator architecture and consolidated within the main algokit-templates repository. Each template's functionality will be decomposed into appropriate base, feature, and example generators to maintain feature parity while improving modularity.
+All Algorand Foundation maintained templates will be migrated to the new generator architecture and consolidated within the main `algokit-templates` repository. Each template's functionality will be decomposed into appropriate base, feature, and example generators to maintain feature parity while improving modularity.
 
 While custom generator creation through the legacy mechanism will no longer be supported, the underlying Copier functionality remains available. The `--template-url` and `--template-url-ref` flags will continue to function for direct Copier template usage, and community templates can still be created as Copier projects and used via `--template-url`. Since generators themselves are Copier projects, community-created generators can theoretically be consumed through these flags.
 
 The specifics of community generator integration and distribution mechanisms are considered out-of-scope for this initial architecture transition and will be addressed in future iterations.
 
-##### Migration Path
+#### Migration Path
 
 The migration to the new generator architecture will be managed primarily through the CLI, with a focus on introducing new functionality without breaking existing workflows until the next major version. The key mechanism for this transition is the introduction of a `beta` command group.
 
 The beta command group provides access to features that are functionally complete but may still undergo changes before being considered stable. These features are in active development and testing, allowing early adopters to experiment with new functionality while maintaining access to stable commands for production use. To use a beta command, users prepend `beta` to the command group, such as `algokit beta init`, which will eventually replace the current `algokit init` with the new TUI workflow.
 
-New commands that don't conflict with existing functionality will be added directly without the beta prefix:
+New commands that don't conflict with existing functionality will be added directly without the need to enable tui feature flag via config command group:
 
-- `algokit project add` - Adds generators to existing projects (base and feature generators only, not example generators)
-- `algokit project add base contracts --language <typescript|python>` - Adds the base contracts generator (workspace-aware)
-- `algokit project add frontend <react|vue|svelte|solid|angular>` - Adds the base frontend generator (workspace-aware)
+* `algokit project add {generator-name}` - Adds generators to existing projects.
 
 This command structure replaces the `algokit generate` workflow for project scaffolding, as `add` better describes the action of layering functionality onto an existing project, while `generate` implies creating something from scratch or producing standalone artifacts.
 
 The existing `algokit generate` command will be deprecated for project generator use in favor of `algokit project add`, though it will continue to function for generating app clients. The new project build process will only guarantee compatibility with projects created using the new generators. While `algokit project add` can be used with older projects, users will receive a warning that this is not recommended, encouraging migration to the new architecture for optimal results.
 
-##### Justification for Dropping Legacy Generators
+#### Justification for Dropping Legacy Generators
 
 The decision to drop legacy generators stems from fundamental maintenance and complexity issues inherent in the current architecture. Legacy generators must be embedded within each project and exist separately in every repository, creating significant code duplication that becomes increasingly difficult to maintain as the number of project examples grows. Additionally, the legacy generators add unnecessary complexity to the templates themselves - the current templates already use Jinja templating which is difficult to understand, and the generators in the `.algokit` folder compound this complexity by also using Jinja templating, making it challenging for developers to comprehend what the generators are actually doing and how they transform the project.
 
-#### Community Extensibility
+### Community Extensibility
 
 Community generator integration and distribution mechanisms fall outside the scope of this initial architecture transition. Future iterations will address how community members can create, share, and discover custom generators, along with the protocols and infrastructure needed to support a thriving ecosystem of third-party generators.
 
-#### Configuration Schemas
+## 2. Dedicated generators monorepo with support for both inline and remote generators
 
-#### How This Satisfies Requirements
+The proposal is an extension to all proposals in Option 1 with the following differences:
 
-| Requirement Category | Requirement | How Option 1 Satisfies |
-|---------------------|-------------|------------------------|
-| **Core Capabilities** | Configuration-Based Generation | YAML configurations specify generators to apply sequentially |
-| | Feature Modularity | Each feature is an independent generator in flat structure |
-| | Idempotency | Generators designed to merge configurations, not overwrite |
-| | Lifecycle Flexibility | Generators can be applied at any time via CLI commands |
-| | Project Structure Support | Separate workspace and non-workspace generators |
-| **User Interaction** | Multiple Creation Methods | TUI wizard, CLI commands, and config files all supported |
-| | Diff Preview | CLI implements diff engine before applying generators |
-| | Conflict Detection | CLI checks existing files and .algokit.toml state |
-| **Project Management** | Feature Status Tracking | All features tracked in [project.generators] section |
-| | Version Tracking | Each generator entry includes version and timestamp |
-| | Compatibility Management | CLI validates versions before applying generators |
-| **Non-Functional** | No Manual Dependencies | CLI bundles all required dependencies |
+* Introduce a dedicated monorepo for all user-facing generators under new repository called `algokit-generators`. The monorepo can reuse already established CI/CD and infrastructure from `algokit-templates` for scaffolding generators and end-to-end testing them.
+* Rename existing `algokit-templates` to `algokit-examples` OR merge with app gallery repository to keep examples used in App Gallery aligned to consumption by App Gallery instead of aiming to serve 2 distinct purposes.
+* Identical to Option 1, rename generator section to project.generators, but maintain support for inline generators. CLI should still behave as is when it discovers an inline generator in the section, giving existing template builders the ability to continue leveraging this use case for scenarios when they have no need for managing and setting up infrastructure for remote generators.
+* Modify path parameter in generator schema under `algokit.toml` to accept paths OR GitHub URLs. This allows supporting remote generators hosted in external repositories. This ensures that not only is support for inline generators preserved, but the concept of remote generators introduced with the monorepo approach is also extended to allow custom community generators to be easily integrated and used.
+* The proposal also slightly modifies the beta feature flag approach in option 1. Instead of explicitly introducing temporary cli semantics via `algokit beta init`, the proposal is to introduce a `algokit config beta` command group to represent beta feature flags for tui based wizard. The feature flag command group provides access to features that are functionally complete but may still undergo changes before being considered stable. These features are in active development and testing, allowing early adopters to experiment with new functionality while maintaining access to stable commands for production use. To enable beta feature, users execute `algokit config beta tui-wizard` to enable it, afterwards regular algokit init switches to the new TUI based workflow. The difference from option one is that this approach does not require introducing temporary semantics into user facing cli commands, while leveraging an already established `config` command group for. The `algokit config beta` allows a convenient central place to lookup preview feature flags and have consistent way to opt into preview functionality as well as a command group to leverage for any new preview features that may be required in future.
 
-## Decision
-[To be filled after review and discussion]
+```mermaid
+flowchart TD
+    A[AlgoKit CLI] --> B{Command Type}
+    
+    B -->|init| C[Init Command]
+    B -->|init examples| D[Init Examples Subcommand]
+    
+    C --> E[TUI Interface for Template Selection]
+    E --> P[Custom YAML Assembly]
+    P --> Q[algokit-generators Monorepo]
 
-## Next Steps
-[To be completed after decision]
+    Q --> X[Sequential Generation]
+    X --> Y[Final Custom Project Assembly]
+    
+    D --> N[TUI Interface for Example Selection]
+    N --> Z[algokit-examples Monorepo]
+    Z --> N[Copy Ready-Made Example from Template Monorepo]
+```
+
+## 3. Hybrid approach enhancing existing standalone templates and remote generators
+
+The following approach borrows ideas from previous options but proposes enhancement of existing patterns over radical architecture revamp.
+
+* Define a notion of lowest common denominator for a base template per each algokit supported programming language. Strip down existing algokit react typescript and python templates to baseline versions removing all Preset templatization (no testing, cicd, linting, formatting and etc) - just the bare minimum starter structure that can be easily extended. This follows principles from option 1 to extract all non essential capabilities into general purpose building blocks.
+* Maintain standalone base template repository as a base for enforcing workspace mode structure. Rename into `algokit-base-workspace-template`.
+* Enhance `algokit-fullstack-template` to act as a bundler for a set of approved pairs of standalone base templates. To a large extend it already acts as one, however removing templatization from base templates significantly simplifies full stack copier.yaml configuration and maintenance costs (less duplicated template answers to manage, clear determenistic number of base templates it can pair up together).
+* Similar to option 2. Introduce a dedicated monorepo for all user facing generators under new repository called `algokit-generators`. The monorepo can reuse already established ci cd and infrastructure from `algokit-templates` for scaffolding generators and e2e testing them.
+* Similar to option 2. Rename existing `algokit-templates` into `algokit-examples` OR merge with app gallery repository to keep examples used in App Gallery close to and purposefully aligned to consumption by App Gallery instead of aiming to serve 2 distinct purposes.
+* Maintain existing non tui based init wizard flow, ensuring it remains functional and accessible for users who prefer a command-line interface. Keep tui based wizard separate and optionally invocable by user after completion of init flow. This ensures that all users always start with a bare minimum and can conveniently select **only** what they need after instantiation of the template. TUI interface for generators can be invoked at any point in existing project lifecycle, in contrast with Option 1 and 2 where TUI based wizard is used primarily as a replacement for initial init flow.
+* Introduce `algokit project add` functionality identical to proposal in Options 1 and 2 allowing invoking inline and remote generators post initialization of the base template.
+
+```mermaid
+flowchart TD
+    A[AlgoKit CLI] --> B{Command Type}
+    
+    B -->|init| C[Init Command]
+    B -->|init examples| D[Init Examples Subcommand]
+    
+    C --> E[Template Selection]
+    E --> F{Predefined Template}
+    
+    F -->|base per language| G[Base Per Language Template Repo]
+    F -->|fullstack| H[Fullstack Template Repo]
+    
+    G --> I[Copier Invocation]
+    H --> I
+    
+    I --> J[TUI Wizard for Generator Selection]
+    J --> K[Fully Configured Custom Project Instance]
+    
+    D --> L[TUI Interface for Example Selection]
+    L --> M[User Configuration]
+    M --> N[Copy Ready-Made Example from Template Monorepo]
+    N --> O[algokit-examples Monorepo]
+```
+
+## 4. CLI-Integrated Generator Engine
+
+The proposed option takes inspiration from Ruby on Rails generators ecosystem that solves versioning challenges by tightly coupling generator versions with the CLI version.
+
+Transform the `AlgoKit` architecture by embedding all generators directly within the CLI binary itself, eliminating external dependencies and version coordination challenges. This approach treats generators as internal CLI components rather than external artifacts, achieving version alignment and reliability through monolithic design.
+
+All generators are bundled inside the CLI binary itself, eliminating ALL external version dependencies and failure modes. This creates a monolithic system where CLI version equals generator versions, removing temporal incompatibility entirely.
+
+```mermaid
+flowchart TD
+    A[`AlgoKit` CLI v3.0.0] --> B[Embedded Generator Engine]
+
+    B --> C[Base Generators]
+    C --> C1[Python Contract Base v3.0.0]
+    C --> C2[TypeScript Contract Base v3.0.0]
+    C --> C3[React Frontend Base v3.0.0]
+    C --> C4[Workspace Structure v3.0.0]
+
+    B --> D[Feature Generators]
+    D --> D1[Testing Framework v3.0.0]
+    D --> D2[Linting Config v3.0.0]
+    D --> D3[CI/CD Pipeline v3.0.0]
+    D --> D4[Docker Setup v3.0.0]
+
+    B --> E[Example Generators]
+    E --> E1[HelloWorld Example v3.0.0]
+    E --> E2[NFT Marketplace v3.0.0]
+    E --> E3[DeFi Protocol v3.0.0]
+
+    B --> F[Generator Coordinator]
+    F --> G[Dependency Resolution]
+    F --> H[Conflict Detection]
+    F --> I[State Management]
+```
+
+### Addressing concerns on supporting external generators
+
+The cli will still depend on leveraging copier functionality internally in order to invoke rendering of bundled jinja templates. Support for instantiation of external templates via --template-url as well as external remote and inline generators can remain intact.
+
+## Pros and Cons of the Options
+
+### Option 1: Flat Generator Architecture with State in .algokit.toml
+
+*Good*, because provides complete modularity with idempotent generators that can be applied at any project lifecycle stage
+
+*Good*, because enhances generators state tracking under `.algokit.toml` file for clear project state visibility
+
+*Good*, because eliminates code duplication across templates, significantly reducing maintenance burden
+
+*Good*, because enables diff preview/dry-run and user approval workflows before applying changes
+
+*Good*, because supports all three user workflows: TUI wizard, CLI commands, and configuration files
+
+*Good*, because it formalizes project configurations with JSON schemas allowing strict config files validation (see [schema definitions](assets/ADR_001/))
+
+*Neutral*, because requires learning new command patterns (`algokit project add` vs current workflows)
+
+*Neutral*, because the option proposes a single monorepo to serve as a reference to app gallery examples but also all user facing generators. Increased complexity of contributing new examples may arise.
+
+*Neutral*, because it removes explicit notion of 'Template' by turning standalone templates into granular generators. The new Template term becomes applicable to a configuration file that defines order of generator execution.
+
+*Bad*, because requires significant architectural refactoring of existing templates accounting for large variety of edge cases and enforcing unique constraints by introducing a notion of portable remote generator.
+
+*Bad*, because community generator extensibility is deferred to future implementation phases
+
+*Bad*, because legacy generators will be deprecated, requiring migration effort from existing projects
+
+### Option 2: Dedicated generators monorepo with support for both inline and remote generators
+
+*Good*, because provides complete modularity with idempotent generators that can be applied at any project lifecycle stage
+
+*Good*, because enhances generators state tracking under `.algokit.toml` file for clear project state visibility
+
+*Good*, because eliminates code duplication across templates, significantly reducing maintenance burden
+
+*Good*, because enables diff preview/dry-run and user approval workflows before applying changes
+
+*Good*, because supports all three user workflows: TUI wizard, CLI commands, and configuration files
+
+*Good*, because it formalizes project configurations with JSON schemas allowing strict config files validation (see [schema definitions](assets/ADR_001/))
+
+*Good*, because the option streamlines maintainability of the repository by splitting algokit-templates into 2 distinct monorepos serving distinct purposes: one for examples on app gallery, one for generic user facing remote generators.
+
+*Good*, because inline generators are still supported and can be used alongside remote generators.
+
+*Good*, because remote community generator extensibility is supported with a minimal modification to the existing generator interface.
+
+*Neutral*, because requires learning new command patterns (`algokit project add` vs current workflows)
+
+*Neutral*, because it removes explicit notion of 'Template' by turning standalone templates into granular generators. The new Template term becomes applicable to a configuration file that defines order of generator execution.
+
+*Bad*, because requires significant architectural refactoring of existing templates accounting for large variety of edge cases and enforcing unique constraints by introducing a notion of portable remote generator.
+
+### Option 3: Hybrid approach enhancing existing standalone templates and remote generators
+
+*Good*, because it preserves existing standalone template infrastructure while gradually introducing modularity, reducing migration risk
+
+*Good*, because it maintains backward compatibility with current CLI workflows while adding new TUI capabilities as an optional enhancement
+
+*Good*, because stripping templates to baseline versions significantly reduces maintenance burden while keeping familiar repository structure
+
+*Good*, because it allows users to start with bare minimum templates and incrementally add only needed features through post-init TUI wizard
+
+*Good*, because it simplifies fullstack template maintenance by removing duplicated template answers and managing deterministic base template pairs
+
+*Good*, because it provides clear separation between base templates (standalone repos) and generators (monorepo), making the architecture easier to understand
+
+*Good*, because it supports both inline and remote generators, providing maximum flexibility for different use cases and community extensions
+
+*Good*, because it formalizes project configurations with JSON schemas allowing strict config files validation (see [schema definitions](assets/ADR_001/))
+
+*Neutral*, because it maintains multiple repositories (base templates + generators monorepo) which could be seen as either good separation of concerns or added complexity
+
+*Bad*, because it still requires maintaining separate template repositories even if simplified. Maintenance cost is a subject to proper evaluation, a counter argument is significant reduction in maintenance due to complete removal of any templatization logic that can be generalized in a remote generator.
+
+*Bad*, because having both standalone templates and generators could lead to feature fragmentation where some capabilities exist in templates and others in generators. This could be mitigated by establishing clear conventions around what should be included in base standalone templates vs moved to portable generators.
+
+*Bad*, because requires significant architectural refactoring of existing templates accounting for large variety of edge cases and enforcing unique constraints by introducing a notion of portable remote generator.
+
+### Option 4: CLI-Integrated Generator Engine
+
+*Good*, because eliminates ALL external version dependencies by embedding generators within CLI binary
+
+*Good*, because achieves temporal compatibility - CLI version equals generator versions
+
+*Good*, because eliminates team version drift through single version coordinate (CLI version)
+
+*Good*, because enables enforced dependency validation and conflict detection at the engine level
+
+*Good*, because provides superior user experience in offline scenarios since all resources are bundled with the CLI
+
+*Good*, because guarantees atomic testing - all generators tested as part of CLI CI/CD workflows
+
+*Good*, because enables maintenance reduction by eliminating template repository duplication
+
+*Good*, because community template/generator extensibility including support for remote/inline generators remains intact
+
+*Bad*, because completely eliminates community template extensibility without CLI forks
+
+*Bad*, because significantly increases development barrier for template contributions
+
+*Bad*, because ties all generator changes to CLI release cycles, affecting development velocity
+
+*Bad*, because it does not eliminate temporal compatibility and versioning issues for third party templates/generators. However, this can be mitigated by providing clear guidelines and tools for maintaining compatibility across versions.
+
+*Bad*, because requires significant architectural refactoring of existing templates accounting for large variety of edge cases and enforcing unique constraints by introducing a notion of portable remote generator.
+
+## More Information
+
+### Option 1 Implementation Details
+
+For detailed implementation specifications of the "Flat Generator Architecture with State in .algokit.toml" option, including functionality distribution, repository structure, and workflow implementation flows, see [Option 1 Implementation Details](assets/ADR_001/option-1-implementation-details.md).
+
+#### Configuration Schema Definitions
+
+The implementation of Option 1 requires formal JSON schema definitions for configuration validation:
+
+#### AlgoKit Project Configuration Schema (.algokit.toml)
+
+* JSON Schema: [algokit-toml-schema.json](assets/ADR_001/algokit-toml-schema.json)
+* Example Configuration: [algokit-toml-example.toml](assets/ADR_001/algokit-toml-example.toml)
+
+#### AlgoKit Template Configuration Schema
+
+* JSON Schema: [template-config-schema.json](assets/ADR_001/template-config-schema.json)
+* YAML Example: [template-config-example.yml](assets/ADR_001/template-config-example.yml)
+* TOML Example: [template-config-example.toml](assets/ADR_001/template-config-example.toml)
+
+These schemas formalize project configurations with strict validation, ensuring consistency across the AlgoKit ecosystem and enabling precise tooling support.
+
+### Option 2 Implementation Details
+
+The given option builds on top of the implementation details proposed in Option 1, hence no additional implementation details are provided here.
+
+> Assumes JSON schema definitions and validation mechanisms similar to Option 1 are in place.
+
+### Option 3 Implementation Details
+
+The given option builds on top of the currently established behaviour in the `AlgoKit` ecosystem, leveraging partial implementation details established in Options 1 and 2. Hence no additional implementation details are provided here.
+
+> Assumes JSON schema definitions and validation mechanisms similar to Option 1 are in place.
+
+### Option 4 Implementation Details
+
+Option 4 represents a fundamental architectural shift requiring complete CLI restructuring. The high level approximation of implementation involves:
+
+* **Generator Engine Integration**: Embedding a full generator coordination engine within the CLI binary
+* **Template Decomposition**: Similar to Option 1-3 involves converting all existing standalone templates into embedded generator modules
+* **Dependency Management**: Implementing runtime dependency validation and conflict detection
+* **State Management**: Centralizing all project state in .algokit.toml with CLI version locking
+* **Migration Tooling**: Providing tools to migrate existing projects to the new embedded generator system
+
+The implementation complexity is equally significant to Options 1-3 with added complexity of bundling artifacts within the CLI. All existing template repositories would be archived and their functionality absorbed into the CLI codebase.
+
+> Assumes JSON schema definitions and validation mechanisms similar to Option 1 are in place.

--- a/docs/architecture-decisions/assets/ADR_001/algokit-toml-example.toml
+++ b/docs/architecture-decisions/assets/ADR_001/algokit-toml-example.toml
@@ -1,0 +1,38 @@
+[algokit]
+min_version = "v2.0.0"  # Remains unchanged
+
+[project]
+# CHANGED: type enum now only includes: contracts, frontend, fullstack
+# REMOVED: "workspace" and "backend" as types (workspace is now a generator)
+type = "fullstack"  
+name = "my-project"
+
+# projects_root_path is only required when workspace generator is applied
+projects_root_path = "projects"
+
+# NEW: Track all applied generators with metadata, exact metadata additions is a subject for discussion outside of adr 1 scope.
+[project.generators]
+workspace = { version = "1.0.0", timestamp = "2024-01-01T00:00:00Z" }
+"base-contracts-python" = { version = "1.0.0", timestamp = "2024-01-01T00:01:00Z" }
+"base-frontend-react" = { version = "1.0.0", timestamp = "2024-01-01T00:02:00Z" }
+testing = { version = "1.0.0", timestamp = "2024-01-01T00:03:00Z", detected_type = "python_contract" }
+linting = { version = "1.0.0", timestamp = "2024-01-01T00:04:00Z" }
+
+# Remains unchanged - populated by generators
+[project.run]
+test = { commands = ["poetry run pytest"], description = "Run smart contract tests" }
+lint = { commands = ["poetry run ruff check"], description = "Check code style" }
+format = { commands = ["poetry run black ."], description = "Format code" }
+
+# Remains unchanged
+[project.deploy]
+command = "poetry run python -m smart_contracts deploy"
+environment_secrets = ["DEPLOYER_MNEMONIC"]
+
+# REMOVED: The entire [generate] section
+# Previously:
+# [generate.smart-contract]
+# description = "Generate a new smart contract"
+# path = ".algokit/generators/smart-contract"
+#
+# This functionality is replaced by `algokit project add` commands

--- a/docs/architecture-decisions/assets/ADR_001/algokit-toml-schema.json
+++ b/docs/architecture-decisions/assets/ADR_001/algokit-toml-schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AlgoKit Configuration Schema",
+  "description": "JSON Schema for .algokit.toml configuration files used by AlgoKit CLI",
+  "type": "object",
+  "properties": {
+    "algokit": {
+      "type": "object",
+      "description": "AlgoKit CLI-specific configuration",
+      "properties": {
+        "min_version": {
+          "type": "string",
+          "description": "Minimum required version of AlgoKit CLI",
+          "pattern": "^v?\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9.-]+)?$",
+          "examples": ["v2.0.0", "1.3.1", "v1.1.0-beta.4"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "project": {
+      "type": "object",
+      "description": "Project configuration and metadata",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of AlgoKit project",
+          "enum": ["contracts", "frontend", "fullstack"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the project",
+          "minLength": 1
+        },
+        "projects_root_path": {
+          "type": "string",
+          "description": "Root path for sub-projects in a workspace",
+          "minLength": 1
+        },
+        "artifacts": {
+          "type": "string",
+          "description": "Path to artifacts directory for contract projects",
+          "minLength": 1
+        },
+        "generators": {
+          "type": "object",
+          "description": "Track applied generators with metadata",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "$ref": "#/$defs/generatorMetadata"
+            }
+          },
+          "additionalProperties": false
+        },
+        "deploy": {
+          "$ref": "#/$defs/deployConfig"
+        },
+        "run": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/workspaceRunConfig"
+            },
+            {
+              "$ref": "#/$defs/standaloneRunConfig"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "generators": {
+                "properties": {
+                  "workspace": {
+                    "type": "object"
+                  }
+                },
+                "required": ["workspace"]
+              }
+            }
+          },
+          "then": {
+            "required": ["projects_root_path"]
+          }
+        }
+      ],
+      "required": ["type", "name"],
+      "additionalProperties": false
+    },
+    "deploy": {
+      "$ref": "#/$defs/deployConfig",
+      "description": "Legacy deploy configuration (deprecated, use project.deploy instead)"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "generatorMetadata": {
+      "type": "object",
+      "description": "Metadata for an applied generator",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Version of the generator that was applied",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "ISO 8601 timestamp when generator was applied",
+          "format": "date-time"
+        },
+        "source": {
+          "type": "string",
+          "description": "Source of the generator (e.g., 'official', URL)",
+          "default": "official"
+        },
+        "detected_type": {
+          "type": "string",
+          "description": "Auto-detected project type for context-aware generators"
+        }
+      },
+      "required": ["version", "timestamp"],
+      "additionalProperties": true
+    },
+    "deployConfig": {
+      "type": "object",
+      "description": "Deployment configuration",
+      "properties": {
+        "command": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Deploy command as a string",
+              "minLength": 1
+            },
+            {
+              "type": "array",
+              "description": "Deploy command as an array of strings",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "environment_secrets": {
+          "type": "array",
+          "description": "List of environment variable names to treat as secrets",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "description": "Network-specific deployment configuration",
+          "properties": {
+            "command": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Deploy command as a string for this network",
+                  "minLength": 1
+                },
+                {
+                  "type": "array",
+                  "description": "Deploy command as an array of strings for this network",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "environment_secrets": {
+              "type": "array",
+              "description": "List of environment variable names to treat as secrets for this network",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "workspaceRunConfig": {
+      "type": "object",
+      "description": "Workspace run configuration defining execution order",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "array",
+          "description": "Ordered list of project names for command execution",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "standaloneRunConfig": {
+      "type": "object",
+      "description": "Standalone project run configuration",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/customCommand"
+        }
+      },
+      "additionalProperties": false
+    },
+    "customCommand": {
+      "type": "object",
+      "description": "Custom command configuration",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "description": "List of commands to execute",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what the command does",
+          "minLength": 1
+        },
+        "env_file": {
+          "type": "string",
+          "description": "Path to environment file to load",
+          "minLength": 1
+        }
+      },
+      "required": ["commands"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/architecture-decisions/assets/ADR_001/option-1-implementation-details.md
+++ b/docs/architecture-decisions/assets/ADR_001/option-1-implementation-details.md
@@ -1,0 +1,150 @@
+# Option 1 Implementation Details
+
+This document contains detailed implementation specifications for the "Flat Generator Architecture with State in .algokit.toml" option.
+
+## Functionality Distribution
+
+| Functionality | CLI Repo | Templates Repo | Copier | Generator Post-Processing | Notes |
+|--------------|----------|----------------|--------|---------------------------|-------|
+| TUI Wizard Interface | ✓ | | | | Interactive UI for project initialization |
+| CLI Command Parsing | ✓ | | | | Parse and validate user commands |
+| Generator Discovery | ✓ | | | | Query available generators from templates |
+| Generator Metadata | | ✓ | | | Dependencies, compatibility, descriptions |
+| Template File Generation | | | ✓ | | Core file generation and templating |
+| Jinja2 Template Processing | | | ✓ | | Variable substitution and conditionals |
+| File Merging Strategy | | | ✓ | | Conflict resolution during file copying |
+| Generator Implementation | | ✓ | | | Copier template definitions and structure |
+| Post-Generation Hooks | | | | ✓ | Scripts run after template application |
+| Configuration Merging | | | | ✓ | Merge configs (package.json, pyproject.toml) |
+| Workflow Orchestration | ✓ | | | | Sequential application of generators |
+| State Management | ✓ | | | | Track applied generators in .algokit.toml |
+| Project Type Detection | ✓ | | | | Analyze existing project structure |
+| Configuration Parsing | ✓ | | | | Parse YAML/TOML configuration files |
+| Compatibility Checking | ✓ | | | | Validate generator combinations |
+| Example Configurations | | ✓ | | | YAML files defining example projects |
+| Hydrated Examples | | ✓ | | | Full example projects for app gallery |
+| Dry run mode | ✓ | | | | Show changes before applying |
+| Conflict Resolution UI | ✓ | | | | Handle file conflicts during generation |
+| Version Management | ✓ | | | | Track generator versions in .algokit.toml |
+
+## Repository Structure
+
+Templates Repository:
+
+```text
+algokit-templates/
+├── generators/                           # All generators (flat structure)
+│   ├── workspace/                       # Creates workspace structure
+│   ├── base-contracts-python/           # Python contract base
+│   ├── base-contracts-typescript/       # TypeScript contract base
+│   ├── base-frontend-react/             # React frontend base
+│   ├── create-smart-contract/           # Create new smart contract
+│   ├── testing/                         # Add testing (auto-detects type)
+│   ├── linting/                         # Add linting configuration
+│   ├── formatting/                      # Add code formatting
+│   ├── devcontainer/                    # Add devcontainer support
+│   ├── ci-cd/                           # Add CI/CD workflows
+│   ├── env-file/                        # Create environment files
+│   ├── example-digital-marketplace/     # Digital marketplace delta
+│   └── example-hello-world/             # Hello world delta
+├── examples/                            # Fully hydrated examples
+│   ├── examples.yml                     # Configuration for generating examples
+│   ├── python-smart-contract/           # Complete project for app gallery
+│   └── digital-marketplace/             # Complete project for app gallery
+└── scripts/
+    └── generate-examples.py             # Build examples from configurations
+```
+
+CLI Repository:
+
+```text
+algokit-cli/
+└── src/
+    └── algokit/
+        ├── cli/
+        │   ├── project/
+        │   │   ├── __init__.py
+        │   │   ├── init.py              # TUI wizard implementation
+        │   │   ├── add.py               # Incremental commands
+        │   │   └── generate.py          # Configuration-based generation
+        │   └── ...
+        └── core/
+            ├── project/
+            │   ├── __init__.py
+            │   ├── generator_registry.py # Discover available generators
+            │   ├── state_manager.py      # Manage state in .algokit.toml
+            │   └── compatibility.py      # Check generator compatibility
+            └── ...
+```
+
+## Workflow Implementation Flows
+
+### Workflow 1: Interactive Wizard (TUI)
+
+There is a spike for this TUI [on GitHub](https://github.com/lempira/template-gallery-spike). Look at the end for a video of the TUI.
+
+```text
+CLI Repo                          Templates Repo
+--------                          --------------
+TUI Wizard -----------------> Query generators/*/copier.yaml
+    |                              |
+Present feature choices            v
+    |                         Return generator metadata
+    v                              |
+User selects features              |
+    |                              |
+Validate selections <--------------+
+    |
+Apply generators sequentially --> Execute each generator
+    |                              |
+Update .algokit.toml               v
+    |                         Apply template files
+    v
+Complete project
+```
+
+### Workflow 2: Incremental CLI Commands
+
+Command to Generator Mapping:
+
+| Command | Generator Name |
+|---------|---------------|
+| `add workspace` | `workspace` |
+| `add base-contracts-python` | `base-contracts-python` |
+| `add base-contracts-typescript` | `base-contracts-typescript` |
+| `add base-frontend-react` | `base-frontend-react` |
+| `add testing` | `testing` |
+| `add linting` | `linting` |
+| `add formatting` | `formatting` |
+
+### Workflow 3: Configuration-Based Generation Example
+
+```yaml
+project:
+  id: python-fullstack-marketplace
+  name: "Digital Marketplace"
+  # Additional metadata that can be used for any purpose e.g. example gallery
+  
+  # Generators applied in order
+  # This is the only config that is needed to build a project
+  # Each generator can run no data because of defaults but can be overridden with the data config.    
+  generators:
+    - name: workspace
+      
+    - name: base-contracts-python
+      
+    - name: create-smart-contract
+      data:
+        language: python
+        contract_name: digital_marketplace
+        
+    - name: example-digital-marketplace
+      
+    - name: base-frontend-react
+      
+    - name: testing
+      
+    - name: linting
+      
+    - name: formatting
+```

--- a/docs/architecture-decisions/assets/ADR_001/template-config-example.toml
+++ b/docs/architecture-decisions/assets/ADR_001/template-config-example.toml
@@ -1,0 +1,29 @@
+id = "python-fullstack-marketplace"
+name = "Digital Marketplace"
+
+[[generators]]
+name = "workspace"
+
+[[generators]]
+name = "base-contracts-python"
+
+[[generators]]
+name = "create-smart-contract"
+[generators.data]
+language = "python"
+contract_name = "digital_marketplace"
+
+[[generators]]
+name = "base-frontend-react"
+
+[[generators]]
+name = "example-digital-marketplace"
+
+[[generators]]
+name = "testing"
+
+[[generators]]
+name = "linting"
+
+[[generators]]
+name = "devcontainer"

--- a/docs/architecture-decisions/assets/ADR_001/template-config-example.yml
+++ b/docs/architecture-decisions/assets/ADR_001/template-config-example.yml
@@ -1,0 +1,15 @@
+# Simplified schema - only essential fields
+id: "python-fullstack-marketplace"
+name: "Digital Marketplace" 
+generators:
+  - name: workspace
+  - name: base-contracts-python
+  - name: create-smart-contract
+    data:
+      language: python
+      contract_name: "digital_marketplace"
+  - name: base-frontend-react
+  - name: example-digital-marketplace
+  - name: testing
+  - name: linting
+  - name: devcontainer

--- a/docs/architecture-decisions/assets/ADR_001/template-config-schema.json
+++ b/docs/architecture-decisions/assets/ADR_001/template-config-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AlgoKit Template Configuration Schema",
+  "description": "Schema for AlgoKit template configuration files",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the template",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string", 
+      "description": "Human-readable name for the template",
+      "minLength": 1
+    },
+    "generators": {
+      "type": "array",
+      "description": "List of generators to apply in sequence",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the generator to apply"
+          },
+          "data": {
+            "type": "object",
+            "description": "Optional data to pass to the generator",
+            "additionalProperties": true
+          }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "required": ["id", "name", "generators"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Restructures an architecture decision record (ADR) for the
`AlgoKit` project generator.

Restructures the adr to follow MADR convention and moves implementation details to separate files.
Adds options 2 to 4 to ADR, providing more alternatives to the proposed architecture.
